### PR TITLE
Breve representation

### DIFF
--- a/lilyNotes/performer.py
+++ b/lilyNotes/performer.py
@@ -105,7 +105,9 @@ class Performer:
 
                 if event.event[1] == "time-sig":
                     self.beats_per_bar = int(event.event[2])
-                    self.score_position.set_beats_per_bar(event.event[2])
+                    self.score_position.set_time_signature(
+                        event.event[2], event.event[3]
+                    )
                     self.beat_structure = {
                         2: [0],
                         3: [0],

--- a/lilyNotes/staff.py
+++ b/lilyNotes/staff.py
@@ -23,6 +23,7 @@ class Staff:
     """
 
     WHITESPACE = re.compile(r"\s+")
+    WEIRD_BREVE_REPRESENTATION = re.compile(r"log = -1")
     CLICKS_PER_BEAT = 384  # 2**8 * 3
 
     def __init__(self, filename, parent=None):
@@ -37,12 +38,13 @@ class Staff:
             for line in f:
                 self.process(line)
 
-    def process(self, l):
+    def process(self, raw_line):
         """
         handle a line from the notes file
         split it into a bunch of fields representing the event
         """
-        fields = Staff.WHITESPACE.split(l)
+        munged_line = Staff.WEIRD_BREVE_REPRESENTATION.sub("0.5", raw_line)
+        fields = Staff.WHITESPACE.split(munged_line)
         self.process_event(fields)
 
     def process_event(self, e):


### PR DESCRIPTION
The lilyNotes code does not look at the lilypond representation of the note's length, so the simple way to fix this is to munge the 
line at first sight to convert the 'log = -1' into a single token - I've chosen '0.5'